### PR TITLE
Fix error in healthysig and fieldworkanalysis_samara vignettes

### DIFF
--- a/vignettes/fieldworkanalysis_samara.Rmd
+++ b/vignettes/fieldworkanalysis_samara.Rmd
@@ -70,11 +70,9 @@ Summary of studies and most frequent taxa increased and decreased in endometrios
 
 ```{r, messages=FALSE}
 bugSigSimple::createStudyTable(subset.dat)
-
-getMostFrequentTaxa(subset.dat,n=30)
-getMostFrequentTaxa(subset.dat,sig.type="increased")
-getMostFrequentTaxa(subset.dat,sig.type="decreased")
-
+getMostFrequentTaxa(subset.dat, n=30)
+getMostFrequentTaxa(subset.dat, direction="UP")
+getMostFrequentTaxa(subset.dat, direction="DOWN")
 ```
 
 # Excluding feces samples
@@ -222,7 +220,7 @@ fit.negbin <-
     data = df,
     control = glm.control(
       epsilon = 1e-8,
-      maxit = 25,
+      maxit = 70,
       trace = FALSE
     )
   )

--- a/vignettes/healthysig.Rmd
+++ b/vignettes/healthysig.Rmd
@@ -43,7 +43,7 @@ healthysig50 <- bugsigdbr::getSignatures(bugs50)
 head(healthysig50)
 ```
 
-```{r healthy0}
+# this code didn't work because experiment 10 has no signatures
 #prevalence threshold=0
 bugs0<- (dat) %>%
   filter (Study=='Study 562') %>%
@@ -52,7 +52,7 @@ bugs0<- (dat) %>%
   filter (grepl("genus",Description))
 healthysig0 <- bugsigdbr::getSignatures(bugs0)  
 head(healthysig0)
-```
+
 
 ```{r healthy70}
 #prevalence threshold=70%
@@ -128,7 +128,7 @@ bugall_decreased <- merge(x = diseasesig_decreased2, y = bugdisease_decreased2,
 ```
 
 ## Calculate pairwise overlaps
-```{r overlap_prevelance=0}
+#this code didn't work because experiment 10 has no signatures, therefore line 130 - 180 were commented out ```{r overlap_prevelance=0}
 library(purrr)
 list0_decreased <- c(healthysig0, diseasesig_decreased)
 paircomp0_decreased <- calcPairwiseOverlaps(list0_decreased)
@@ -154,10 +154,10 @@ paircheck0_increased <- paircomp0_increased %>%
           signature_id= purrr::map_chr(stringr::str_split(purrr::map_chr(name2_2, 3),'_'),1)
         ) 
 ```
-## merge jacard scores with disease study data
+# merge jacard scores with disease study data
 The issue why I need to merge overlap score back with all disease budsigdb studies is that calcPairwiseOverlaps drops all 0 intersect pairs
 
-```{r merge overlap scores with all disease study data}
+#```{r merge overlap scores with all disease study data}
 overlap0_decreased<- merge(x = bugall_decreased, y = paircheck0_decreased, by =c('study_id','experiment_id','signature_id'), all.x = TRUE) %>%
   mutate(type="decreased")%>%
   filter(length_set2>4) #keep only bugsigdb studies that tested more than 4 increased or decreased
@@ -169,7 +169,7 @@ overlap0_increased<- merge(x = bugall_increased, y = paircheck0_increased, by =c
 overlap0_increased[is.na(overlap0_increased)] <- 0  
 ```
 
-```{r comparison-increased_vs_decrease}
+#```{r comparison-increased_vs_decrease}
 t.test(overlap0_increased$overlap, overlap0_decreased$overlap)
 wilcox.test(overlap0_increased$overlap, overlap0_decreased$overlap)
 
@@ -178,6 +178,7 @@ p <- rbind(overlap0_increased,overlap0_decreased) %>%
     geom_histogram( color="#e9ecef", alpha=0.6, position = 'dodge',bins=20) 
 p
 ```
+
 
 ```{r overlap_prevelance=50}
 library(purrr)


### PR DESCRIPTION
Hi Chloe,

This is an attempt to resolve the errors occurring during the knitting of the healthysig.Rmd and fieldworldanalysis_samara.Rmd vignettes by correcting the code causing the issue.

In healthysig.Rmd vignette, I noticed that the error was coming from **line 46 to 54**, when I checked Study 562/ experiment 10 had no signatures. This is why I think this error occurred. As a result, I commented out lines 46 to 54 as well as lines 130 to 180 where the bugs0 and healthysig0 objects were used. 

In fieldworldanalysis_samara.Rmd vignette, the error occurred at **lines 71 - 76**, where the 'getMostFrequentTaxa' function wasn't correctly used, decided to update it by inserting 'directions' instead.
Another error at **line 223** was corrected by changing 'maxit = 24' to 'maxit = 70'.

The vignettes were successfully built after these changes were made. I'm open to your feedback and corrections. 