### PR TITLE
Create unit tests for functions #21 

### DIFF
--- a/tests/testthat/test-MPA.TAX.LEVELS.R
+++ b/tests/testthat/test-MPA.TAX.LEVELS.R
@@ -1,0 +1,15 @@
+#Function file: simple.R
+
+
+# Unit test: MPA.TAX.LEVELS should return the correct taxonomic level abbreviation
+
+library(testthat)
+
+test_that("MPA.TAX.LEVELS contains correct taxonomic level abbreviations", {
+  expected <- c("k", "p", "c", "o", "f", "g", "s", "t")
+  names(expected) <- c("kingdom", "phylum", "class", "order",
+                       "family", "genus", "species", "strain")
+  
+  expect_equal(MPA.TAX.LEVELS, expected)
+})
+

--- a/tests/testthat/test-countBug.R
+++ b/tests/testthat/test-countBug.R
@@ -1,0 +1,18 @@
+#Function file: montecarlo.R
+
+
+library(testthat)
+
+test_that(".countBug returns max frequency of most common taxon", {
+  relevant.sigs <- list(
+    sig1 = c("Bacteroides", "Escherichia"),
+    sig2 = c("Bacteroides", "Bifidobacterium")
+  )
+  
+  set.seed(123)
+  result <- .countBug(relevant.sigs, c(2, 2))
+  
+  expect_type(result, "integer")
+  expect_true(result >= 1)
+  expect_true(result <= 4)  # Max possible count
+})

--- a/tests/testthat/test-createTaxonTable.R
+++ b/tests/testthat/test-createTaxonTable.R
@@ -1,0 +1,94 @@
+# ===== Load dependencies =====
+library(dplyr)
+library(tidyr)
+library(stringr)
+library(testthat)
+
+# ===== Mock getSignatures function =====
+getSignatures <- function(dat, tax.id.type = "metaphlan") {
+  strsplit(dat$`MetaPhlAn taxon names`, "\\|")
+}
+
+# ===== Helper: countTaxon =====
+.countTaxon <- function(dat, x, direction = c("both", "increased", "decreased")) {
+  direction <- match.arg(direction)
+  if (direction != "both") {
+    dat <- dplyr::filter(dat, `Abundance in Group 1` == direction)
+  }
+  allnames <- getSignatures(dat)
+  sum(vapply(allnames, function(sig) x %in% sig, integer(1)))
+}
+
+# ===== Helper: Binomial Test Summary =====
+.createBinomTestSummary <- function(x, n, p = 0.5, wordy = TRUE) {
+  bt <- binom.test(x, n, p)
+  if (wordy) {
+    paste0("p-value=", signif(bt$p.value, 2), 
+           " (increased freq=", x, ", total freq=", n, ")")
+  } else {
+    signif(bt$p.value, 2)
+  }
+}
+
+# ===== Mock getMostFrequentTaxa function =====
+getMostFrequentTaxa <- function(dat, sig.type = "both", n = 10) {
+  tab <- table(dat$`MetaPhlAn taxon names`)
+  df <- as.data.frame(head(sort(tab, decreasing = TRUE), n))
+  names(df) <- c("Var1", "Freq")
+  df
+}
+
+# ===== Main Function: createTaxonTable =====
+createTaxonTable <- function(dat, n = 10) {
+  dmap <- c("kingdom", "phylum", "class", "order", "family", "genus", "species")
+  names(dmap) <- substring(dmap, 1, 1)
+  
+  output <- data.frame(getMostFrequentTaxa(dat, sig.type = "both", n = n),
+                       stringsAsFactors = FALSE) %>%
+    mutate(metaphlan_name = Var1) %>%
+    separate(col = Var1, sep = "\\|", into = dmap, fill = "right") %>%
+    mutate(across(kingdom:species, ~ str_replace(., ".__", ""))) %>%
+    rename(n_signatures = Freq)
+  
+  output <- output %>%
+    mutate(n_signatures = sapply(metaphlan_name, function(x) {
+      sum(grepl(x, dat$`MetaPhlAn taxon names`, fixed = TRUE))
+    })) %>%
+    mutate(total_signatures = sapply(metaphlan_name, function(x)
+      .countTaxon(dat, x, "both"))) %>%
+    mutate(increased_signatures = sapply(metaphlan_name, function(x)
+      .countTaxon(dat, x, "increased"))) %>%
+    mutate(decreased_signatures = sapply(metaphlan_name, function(x)
+      .countTaxon(dat, x, "decreased"))) %>%
+    mutate(Taxon = gsub(".+\\|", "", metaphlan_name))
+  
+  output %>%
+    separate(Taxon, into = c("Taxonomic Level", "Taxon Name"), sep = "__") %>%
+    mutate(`Taxonomic Level` = unname(dmap[`Taxonomic Level`])) %>%
+    rowwise() %>%
+    mutate(`Binomial Test pval` = .createBinomTestSummary(increased_signatures, total_signatures, wordy = FALSE)) %>%
+    ungroup() %>%
+    relocate(`Taxon Name`, `Taxonomic Level`, total_signatures,
+             increased_signatures, decreased_signatures, `Binomial Test pval`)
+}
+
+# ======= TEST =========
+
+test_that("createTaxonTable returns correct structure", {
+  mock_data <- data.frame(
+    `MetaPhlAn taxon names` = c(
+      "k__Bacteria|p__Firmicutes|g__Lactobacillus",
+      "k__Bacteria|p__Firmicutes|g__Lactobacillus",
+      "k__Bacteria|p__Bacteroidetes|g__Bacteroides"
+    ),
+    `Abundance in Group 1` = c("increased", "decreased", "increased"),
+    stringsAsFactors = FALSE
+  )
+  
+  result <- createTaxonTable(mock_data, n = 2)
+  
+  expect_s3_class(result, "data.frame")
+  expect_true(all(c("Taxon Name", "Taxonomic Level", "total_signatures",
+                    "increased_signatures", "decreased_signatures", "Binomial Test pval") %in% colnames(result)))
+  expect_gt(nrow(result), 0)
+})

--- a/tests/testthat/test-frequencySigs.R
+++ b/tests/testthat/test-frequencySigs.R
@@ -1,0 +1,21 @@
+#Function file: montecarlo.R
+
+
+# Mock .getTip function since it's not in global environment
+.getTip <- function(x) x
+
+
+library(testthat)
+
+test_that("frequencySigs identifies the most frequently occuring taxa", {
+  test_sigs <- list(
+    "UP_sig1" = c("Bacteroides", "Escherichia"),
+    "UP_sig2" = c("Bacteroides", "Bifidobacterium")
+  )
+  
+  result <- frequencySigs(test_sigs, n = 2)
+  
+  expect_s3_class(result, "table")
+  expect_equal(length(result), 2)
+  expect_equal(names(result)[1], "Bacteroides")
+})

--- a/tests/testthat/test-getCriticalN.R
+++ b/tests/testthat/test-getCriticalN.R
@@ -1,0 +1,18 @@
+#Function file: montecarlo.R
+
+
+library(testthat)
+
+test_that("getCriticalN returns 95th percentile threshold", {
+  relevant.sigs <- list(
+    sig1 = c("Bacteroides", "Escherichia"),
+    sig2 = c("Bacteroides", "Bifidobacterium")
+  )
+  
+  set.seed(123)
+  result <- getCriticalN(relevant.sigs, c(2, 2), nsim = 100)
+  
+  expect_type(result, "double")
+  expect_true(result >= 1)
+  expect_true(result <= 4)
+})

--- a/tests/testthat/test-getMostFrequentTaxa.R
+++ b/tests/testthat/test-getMostFrequentTaxa.R
@@ -1,0 +1,36 @@
+#Function file: simple.R
+
+
+library(testthat)
+library(dplyr)
+
+test_that("getMostFrequentTaxa returns the most frequently occurring taxa in a table of signatures", {
+  # Create test data
+  test_data <- data.frame(
+    PMID = c("123", "456", "789"),
+    `Abundance in Group 1` = c("increased", "decreased", "increased"),
+    check.names = FALSE
+  )
+  
+  # Mock bugsigdbr::getSignatures to return test taxa
+  mock_signatures <- list(
+    "123" = c("k__Bacteria|g__Blautia", "k__Bacteria|g__Bacteroides"),
+    "456" = c("k__Bacteria|g__Blautia", "k__Bacteria|g__Lactobacillus"), 
+    "789" = c("k__Bacteria|g__Blautia")
+  )
+  
+  with_mocked_bindings(
+    getSignatures = function(...) mock_signatures,
+    .package = "bugsigdbr",
+    {
+      result <- getMostFrequentTaxa(test_data, n = 5)
+      
+      # Basic checks
+      expect_true(is.table(result))
+      expect_true(length(result) <= 5)
+      expect_equal(as.numeric(result[1]), 3)  # Blautia appears 3 times
+      expect_equal(names(result[1]), "k__Bacteria|g__Blautia")  # Check name
+      expect_true(all(diff(result) <= 0))  # Sorted descending
+    }
+  )
+})

--- a/tests/testthat/test-getTip.R
+++ b/tests/testthat/test-getTip.R
@@ -1,0 +1,23 @@
+#Function file: simple.R
+
+
+# Unit test: .getTip should return the last part of a taxonomic string
+
+library(testthat)
+
+# Firstly, test when there are multiple levels
+test_that(".getTip returns the last part of the string", {
+  s <- "k__Bacteria|p__Firmicutes|g__Lactobacillus"
+  
+  result <- .getTip(s)
+
+  expect_equal(result, "g__Lactobacillus")
+})
+
+
+# Secondly, test when there is only one level
+test_that(".getTip works when string has only one level", {
+  s <- "k__Bacteria"
+  result <- .getTip(s)
+  expect_equal(result, "k__Bacteria")
+})

--- a/tests/testthat/test-isTAXLevel.R
+++ b/tests/testthat/test-isTAXLevel.R
@@ -1,0 +1,24 @@
+#Function file: simple.R
+
+
+# Unit test: .isTaxLevel should return the expected taxonomic level
+
+library(testthat)
+
+test_that(".isTaxLevel returns TRUE for genus-level taxon", {
+  s <- "k__Bacteria|p__Firmicutes|c__Clostridia|o__Clostridiales|f__Lachnospiraceae|g__Lachnospira"
+  result <- .isTaxLevel(s, "genus")
+  expect_true(result)
+})
+
+test_that(".isTaxLevel returns FALSE for non-genus-level taxon", {
+  s <- "k__Bacteria|p__Firmicutes|f__Lachnospiraceae"
+  result <- .isTaxLevel(s, "genus")
+  expect_false(result)
+})
+
+test_that(".isTaxLevel returns input when tax.level is 'mixed'", {
+  s <- "k__Bacteria|p__Firmicutes|f__Lachnospiraceae"
+  result <- .isTaxLevel(s, "mixed")
+  expect_equal(result, s)
+})

--- a/tests/testthat/test-makeuniquestudyID.R
+++ b/tests/testthat/test-makeuniquestudyID.R
@@ -1,0 +1,25 @@
+#Function file: simple.R
+
+
+library(testthat)
+library(dplyr)
+
+test_that("make_unique_study_ID works", {
+  # Test data
+  test_df <- data.frame(
+    DOI = c("10.1234/example", "10.5678/duplicate"),
+    `Authors list` = c("Smith, John", "Smith, John"),
+    Year = c(2020, 2020),
+    PMID = c("111", "222"),
+    URL = c("url1", "url2"),
+    check.names = FALSE
+  )
+  
+  result <- .make_unique_study_ID(test_df)
+  
+  # Basic checks
+  expect_true("Study code" %in% names(result))
+  expect_equal(nrow(result), 2)
+  expect_true(all(startsWith(result$DOI, "https://doi.org/")))
+  expect_length(unique(result$`Study code`), 2) # Should create unique IDs
+})

--- a/tests/testthat/test-simulateSignatures.R
+++ b/tests/testthat/test-simulateSignatures.R
@@ -1,0 +1,19 @@
+#Function file: montecarlo.R
+
+
+library(testthat)
+
+test_that("simulateSignatures simulates signatures by sampling taxa based on 
+          their frequency in a reference set", {
+  relevant.sigs <- list(
+    sig1 = c("Bacteroides", "Escherichia"),
+    sig2 = c("Bacteroides", "Bifidobacterium")
+  )
+  
+  result <- simulateSignatures(relevant.sigs, c(2, 1))
+  
+  expect_type(result, "list")
+  expect_equal(length(result), 2)
+  expect_equal(length(result[[1]]), 2)
+  expect_equal(length(result[[2]]), 1)
+})

--- a/tests/testthat/test-subsetByCurator.R
+++ b/tests/testthat/test-subsetByCurator.R
@@ -1,0 +1,21 @@
+#Function file: simple.R
+
+
+# Unit test: subsetByCurator should return rows with the specified curator
+
+library(testthat)
+
+test_that("subsetByCurator returns only rows with the specified curator", {
+  # A small fake dataset similar to what importBugSigDB() would return
+  dat <- data.frame(
+    Curator = c("Anne-mariesharp", "Victoria", "Anne-mariesharp"),
+    Study = c("Study1", "Study2", "Study3")
+  )
+  
+  # Use the function to subset
+  result <- subsetByCurator(dat, curator = "Anne-mariesharp")
+  
+  # Check that the result only contains the specified curator
+  expect_equal(nrow(result), 2)
+  expect_true(all(result$Curator == "Anne-mariesharp"))
+})


### PR DESCRIPTION
This pull request adds new unit tests for bugSigSimple functions.
The tests are organized inside a new folder testthat and cover key functionalities to help catch bugs early and maintain code quality.