### PR TITLE
Fix vignette column names and chunk options

### DIFF
--- a/vignettes/capstoneanalysis_BearklandM.Rmd
+++ b/vignettes/capstoneanalysis_BearklandM.Rmd
@@ -17,7 +17,7 @@ install.packages("xfun")
 ```
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(results = 'hide', fig.show = 'hide')
+knitr::opts_chunk$set(echo = TRUE, message = FALSE, warning = FALSE)
 ```
 
 ```{r}
@@ -326,9 +326,9 @@ lapply(unique(clusts), function(i) names(clusts)[clusts == i])
 ```{r}
 #all taxon increased and decreased freq
 allfreqs <- bugSigSimple::createTaxonTable(subset.final, n = 500) %>% #could change number
-  arrange(I(decreased_signatures - increased_signatures))
-incfreqs <- filter(allfreqs, I(increased_signatures - decreased_signatures) > 0)
-decfreqs <- filter(allfreqs, I(increased_signatures - decreased_signatures) < 0)
+  arrange(I(`Decreased Signatures` - `Increased Signatures`))
+incfreqs <- filter(allfreqs, I(`Increased Signatures` - `Decreased Signatures`) > 0)
+decfreqs <- filter(allfreqs, I(`Increased Signatures` - `Decreased Signatures`) < 0)
 kableExtra::kbl(allfreqs) %>%
   kable_paper("hover", full_width = FALSE)
 ```

--- a/vignettes/fieldworkanalysis_samara.Rmd
+++ b/vignettes/fieldworkanalysis_samara.Rmd
@@ -100,9 +100,9 @@ reproductive_sigs <-
 bugSigSimple::createStudyTable(reproductive_sigs)
 
 allfreqs <- bugSigSimple::createTaxonTable(reproductive_sigs, n = 20) %>% #could change number
-  arrange(I(decreased_signatures - increased_signatures))
-incfreqs <- filter(allfreqs, I(increased_signatures - decreased_signatures) > 0)
-decfreqs <- filter(allfreqs, I(increased_signatures - decreased_signatures) < 0)
+  arrange(I(`Decreased Signatures` - `Increased Signatures`))
+incfreqs <- filter(allfreqs, I(`Increased Signatures` - `Decreased Signatures`) > 0)
+decfreqs <- filter(allfreqs, I(`Increased Signatures` - `Decreased Signatures`) < 0)
 kableExtra::kbl(allfreqs) %>%
   kable_paper("hover", full_width = FALSE)
 ```


### PR DESCRIPTION
- Update column names for decreased/increased signatures to fix 'object not found' errors.
- Change knitr opts_chunk in capstoneanalysis_BearklandM.Rmd to echo results and display figures.

Acknowledges Gemini Code Assist.