### PR TITLE
Fix errors in createStudyTable and getCriticalN tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: bugSigSimple
-Version: 0.99.6
-Date: 2022-03-07
+Version: 0.99.7
+Date: 2026-06-01
 Title: Simple exploratory analysis of curated microbe signatures 
 Authors@R: c(person("Ludwig", "Geistlinger", email = "Ludwig_Geistlinger@hms.harvard.edu", role = c("aut", "cre")),
     person("Chloe", "Mirzayi", email = "chloe.mirzayi@sph.cuny.edu", role = c("aut")),

--- a/R/describe_curation.R
+++ b/R/describe_curation.R
@@ -119,7 +119,7 @@ createStudyTable <- function(bsdb.df, includeAlso = NULL) {
   
   # some dplyr-fu to summarize tables, with more recent syntax
   study_table_fixed <- bsdb_with_StudyCodes.df %>%
-    group_by(`Study code`) %>%
+    group_by(`Study Identifier`) %>%
     reframe(
       MaxCases = max(`Group 1 sample size`),
       MaxControls = max(`Group 0 sample size`),
@@ -164,7 +164,7 @@ globalVariables(
     "PMID",
     "URL",
     "uniqueRank",
-    "Study code",
+    "Study Identifier",
     "Group 0 sample size",
     "Group 1 sample size",
     "N_signatures"

--- a/R/describe_curation.R
+++ b/R/describe_curation.R
@@ -115,10 +115,10 @@ createStudyTable <- function(bsdb.df, includeAlso = NULL) {
   # Core of the change is in how study IDs are generated, see function in 
   # simple.R. NB: the function also fixes DOI links as side effect, now. 
   
-  bsdb_with_StudyCodes.df <- .make_unique_study_ID(bsdb.df)
+  bsdb_with_StudyIDs.df <- .make_unique_study_ID(bsdb.df)
   
   # some dplyr-fu to summarize tables, with more recent syntax
-  study_table_fixed <- bsdb_with_StudyCodes.df %>%
+  study_table_fixed <- bsdb_with_StudyIDs.df %>%
     group_by(`Study Identifier`) %>%
     reframe(
       MaxCases = max(`Group 1 sample size`),

--- a/tests/testthat/test-getCriticalN.R
+++ b/tests/testthat/test-getCriticalN.R
@@ -9,7 +9,8 @@ test_that("getCriticalN returns 95th percentile threshold", {
   set.seed(123)
   result <- getCriticalN(relevant.sigs, c(2, 2), nsim = 100)
   
-  expect_type(result, "double")
-  expect_true(result >= 1)
-  expect_true(result <= 4)
+  expect_type(result, "list")
+  expect_type(result$critical_n, "double")
+  expect_true(result$critical_n >= 1)
+  expect_true(result$critical_n <= 4)
 })

--- a/tests/testthat/test-makeuniquestudyID.R
+++ b/tests/testthat/test-makeuniquestudyID.R
@@ -14,8 +14,8 @@ test_that("make_unique_study_ID works", {
   result <- .make_unique_study_ID(test_df)
   
   # Basic checks
-  expect_true("Study code" %in% names(result))
+  expect_true("Study Identifier" %in% names(result))
   expect_equal(nrow(result), 2)
   expect_true(all(startsWith(result$DOI, "https://doi.org/")))
-  expect_length(unique(result$`Study code`), 2) # Should create unique IDs
+  expect_length(unique(result$`Study Identifier`), 2) # Should create unique IDs
 })

--- a/vignettes/c-section_meconium_shaimaa.Rmd
+++ b/vignettes/c-section_meconium_shaimaa.Rmd
@@ -19,7 +19,7 @@ vignette: >
 # Making sure packages are installed
 
 Not evaluated in vignette:
-```{r, eval=FALSE, messages=FALSE}
+```{r, eval=FALSE, message=FALSE}
 if (!require("BiocManager", quietly = TRUE))
     install.packages("BiocManager")
 BiocManager::install(c("devtools", "tidyverse", "kableExtra"))
@@ -28,15 +28,13 @@ BiocManager::install(c("waldronlab/bugSigSimple", "waldronlab/BugSigDBStats", "w
 
 # Load and subset data
 
-```{r, messages=FALSE}
+```{r, message=FALSE}
 suppressPackageStartupMessages({
   library(bugSigSimple)
   library(BugSigDBStats)
   library(bugsigdbr)
   library(tidyverse)
-  library(stringr)
   library(kableExtra)
-  library(dplyr)
 })
 ```
 
@@ -49,7 +47,7 @@ names(dat)
 
 # Subsetting
 
-```{r, messages=FALSE}
+```{r, message=FALSE}
 included.pmid <-
   c(
     28018325,
@@ -64,7 +62,8 @@ included.pmid <-
     27362264
   )
 subset.dat <-
-  filter(dat, PMID %in% included.pmid) 
+  dat %>%
+  dplyr::filter(PMID %in% included.pmid) 
 ```
 
 ```{r group0}
@@ -81,20 +80,17 @@ included.group1 <- "C-section"
 
 ```{r}
 subset.final <-
-  filter(subset.dat, `Group 0 name` %in% included.group0 & `Group 1 name` %in% included.group1) %>%
-  filter(`Body site` == "Meconium") %>%
-  arrange(PMID)
+  subset.dat %>%
+  dplyr::filter(`Group 0 name` %in% included.group0, `Group 1 name` %in% included.group1) %>%
+  dplyr::filter(`Body site` == "Meconium") %>%
+  dplyr::arrange(PMID)
 ```
 
 Show key characteristics of the included signatures:
 
 ```{r}
-detach("package:dplyr", unload = TRUE)
-library(dplyr)
-```
-
-```{r}
-select(subset.final, "PMID", "Source", "Group 0 name", "Group 1 name", "Abundance in Group 1")
+subset.final %>%
+  dplyr::select("PMID", "Source", "Group 0 name", "Group 1 name", "Abundance in Group 1")
 ```
 
 Are any studies missing?
@@ -120,7 +116,9 @@ createStudyTable(subset.final) %>%
 This table summarizes the results for the top `n` most frequently identified taxa.
 
 ```{r}
-kable_styling(kbl(bugSigSimple::createTaxonTable(subset.final, n = 20)))
+bugSigSimple::createTaxonTable(subset.final, n = 20) %>% 
+  kbl() %>% 
+  kable_styling()
 ```
 
 

--- a/vignettes/c-section_meconium_shaimaa.Rmd
+++ b/vignettes/c-section_meconium_shaimaa.Rmd
@@ -137,3 +137,8 @@ getMostFrequentTaxa(subset.final, direction="UP")
 ```{r}
 getMostFrequentTaxa(subset.final, direction="DOWN")
 ```
+
+# Acknowledgements
+
+This vignette was refactored with the assistance of Gemini Code Assist.
+


### PR DESCRIPTION
This PR fixes issues identified while running the c-section meconium vignette.

- Updated `createStudyTable` and its tests to accommodate the recent change from `Study code` to `Study Identifier`.
- Updated the `getCriticalN` tests to reflect the new `list` return type.

Co-authored-by: Gemini Code Assist <gemini@google.com>