### PR TITLE
Fix vignette install/file-write/filter issues from issue #46

### DIFF
--- a/vignettes/capstoneanalysis_BearklandM.Rmd
+++ b/vignettes/capstoneanalysis_BearklandM.Rmd
@@ -107,7 +107,19 @@ subset.dat %>%
 Final subset to include only those Group 0 names of interest (controls with no DED) and only those Group 1 names of interest (some variation on DED)
 
 ```{r}
-subset.final <- subset.dat[which(subset.dat$`Group 0 name` %in% c("Healthy Control", "Control", "control", "healthy controls", "Normal Control (NC)","Healthy control", "Healthy Controls","Normal healthy (NDM) children", "Healthy controls")& subset.dat$`Group 1 name`%in% c("Meibomian Gland Dysfunction + Lacrimal Dysfunction", "Meibomian Gland Dysfunction", "Dry Eye","ADDE", "DED patients", "MGD", "Meibomian Gland Dysfunction (MGD)", "Meibomian Gland Dysfunction (MGD) DED", "Meibomian Gland Dysfunction (MGD) Groups", "Mixed DED", "Sjogrens Syndrome Dry Eye (SSDE)", "Non Sjogrens Syndrome Dry Eye (NSSDE)", "Dry Eye Disease patients", "Sjogren's patients with Dry Eye Disease", "Dry Eye Disease patients without Sjogrens", "Diabetic children with Dry Eye Disease (DM-DE)", "Mild Dry Eye", "Mild and Moderate to Severe Dry Eye")),]
+group0.controls <- c("Healthy Control", "Control", "control", "healthy controls",
+                      "Normal Control (NC)", "Healthy control", "Healthy Controls",
+                      "Normal healthy (NDM) children", "Healthy controls")
+group1.ded <- c("Meibomian Gland Dysfunction + Lacrimal Dysfunction", "Meibomian Gland Dysfunction",
+                "Dry Eye", "ADDE", "DED patients", "MGD", "Meibomian Gland Dysfunction (MGD)",
+                "Meibomian Gland Dysfunction (MGD) DED", "Meibomian Gland Dysfunction (MGD) Groups",
+                "Mixed DED", "Sjogrens Syndrome Dry Eye (SSDE)", "Non Sjogrens Syndrome Dry Eye (NSSDE)",
+                "Dry Eye Disease patients", "Sjogren's patients with Dry Eye Disease",
+                "Dry Eye Disease patients without Sjogrens", "Diabetic children with Dry Eye Disease (DM-DE)",
+                "Mild Dry Eye", "Mild and Moderate to Severe Dry Eye")
+
+subset.final <- subset.dat[subset.dat$`Group 0 name` %in% group0.controls &
+                              subset.dat$`Group 1 name` %in% group1.ded, ]
 
 subset.final %>%
   kbl() %>%
@@ -127,9 +139,12 @@ bugSigSimple::createStudyTable(subset.final)|> kableExtra::kbl()
 
 This table summarizes the results for the identified taxa.
 
-```{r}
-# Install and load necessary packages
+```{r, eval=FALSE}
 install.packages("openxlsx")
+```
+
+```{r}
+# Load necessary packages
 library(openxlsx)
 library(knitr)
 
@@ -147,16 +162,16 @@ addWorksheet(wb, "Taxon Table")
 writeData(wb, "Taxon Table", taxon_table)
 
 # Save the workbook
-saveWorkbook(wb, "TaxonTable.xlsx", overwrite = TRUE)
+saveWorkbook(wb, file.path(tempdir(), "TaxonTable.xlsx"), overwrite = TRUE)
 
 ```
 
-```{r}
+```{r, eval=FALSE}
 install.packages("writexl")
 
 ```
 
-```{r}
+```{r, eval=FALSE}
 install.packages("ontologyIndex")
 ```
 
@@ -218,7 +233,7 @@ print(plot)
 
 
 # Save the plot to a file
-ggsave("bar_graph.png", plot)
+ggsave(file.path(tempdir(), "bar_graph.png"), plot)
 
 
 ```
@@ -295,7 +310,7 @@ draw(hm,
      annotation_legend_side = "right")
 
 # Save the heatmap as an image
-png("heatmap.png", width = 12, height = 8, units = "in", res = 300)
+png(file.path(tempdir(), "heatmap.png"), width = 12, height = 8, units = "in", res = 300)
 draw(hm, 
      heatmap_legend_side = "bottom", 
      annotation_legend_side = "right")
@@ -320,7 +335,7 @@ hc <- hclust(dist(jmat))
 plot(hc)
 
 # Save the cluster map as an image
-png("cluster_map.png", width = 12, height = 8, units = "in", res = 300)
+png(file.path(tempdir(), "cluster_map.png"), width = 12, height = 8, units = "in", res = 300)
 plot(hc, main = "Hierarchical Cluster Map of Signatures", xlab = "", sub = "", cex = 0.6)
 dev.off()
 

--- a/vignettes/fieldworkanalysis_samara.Rmd
+++ b/vignettes/fieldworkanalysis_samara.Rmd
@@ -49,19 +49,21 @@ names(dat)
 Subsetting only studies done on humans - 6 of 17 studies were excluded because they were either done on mice or not statistically reliable (Cregger et. al)
 
 ```{r, messages=FALSE}
-subset.dat <-
-  dat[which(
-    dat$PMID == "30778155" |
-      dat$PMID == "32192080" |
-      dat$PMID == "31087436" |
-      dat$PMID == "26901400" |
-      dat$PMID == "33839907" |
-      dat$PMID == "32046455" |
-      dat$PMID == "33925708" |
-      dat$PMID == "32299442" |
-      dat$PMID == "33313185" |
-      dat$PMID == "34268384" | dat$PMID == "33660232"
-  ), ]
+included.pmid <-
+  c(
+    "30778155",
+    "32192080",
+    "31087436",
+    "26901400",
+    "33839907",
+    "32046455",
+    "33925708",
+    "32299442",
+    "33313185",
+    "34268384",
+    "33660232"
+  )
+subset.dat <- dat[dat$PMID %in% included.pmid, ]
 ```
 
 # All studies
@@ -95,17 +97,19 @@ getMostFrequentTaxa(subset.dat, direction="DOWN") %>%
 Summary of studies and most frequent taxa in only samples from female reproductive tract, excluding feces samples
 
 ```{r, messages=FALSE}
-subset.dat2 <-
-  dat[which(
-    dat$PMID == "30778155" |
-      dat$PMID == "32192080" |
-      dat$PMID == "31087436" |
-      dat$PMID == "26901400" |
-      dat$PMID == "32046455" |
-      dat$PMID == "33925708" |
-      dat$PMID == "32299442" |
-      dat$PMID == "33313185" | dat$PMID == "34268384"
-  ), ]
+included.pmid2 <-
+  c(
+    "30778155",
+    "32192080",
+    "31087436",
+    "26901400",
+    "32046455",
+    "33925708",
+    "32299442",
+    "33313185",
+    "34268384"
+  )
+subset.dat2 <- dat[dat$PMID %in% included.pmid2, ]
 
 reproductive_sigs <-
   subset.dat2[which(subset.dat2$`Body site` != "feces" |

--- a/vignettes/goldstandard_vignette_peace.Rmd
+++ b/vignettes/goldstandard_vignette_peace.Rmd
@@ -279,7 +279,7 @@ draw(
 
 # Save the heatmap as a high-resolution PNG
 png(
-  filename = "MASLD_heatmap.png",
+  filename = file.path(tempdir(), "MASLD_heatmap.png"),
   width = 14,
   height = 10,
   units = "in",


### PR DESCRIPTION
this PR introduces fixes to the open issue #46   and for not gate stray `install.packages()` calls behind `eval=FALSE`, redirect hardcoded file outputs (`xlsx/png)` to `tempdir(),` and simplify `which()-wrapped` OR-chain filters to %in% across three vignettes.
All filter rewrites verified byte-identical via synthetic-data
equivalence tests.

Closes : #46 

